### PR TITLE
Update BAF.ps1

### DIFF
--- a/start_script/BAF.ps1
+++ b/start_script/BAF.ps1
@@ -1,4 +1,4 @@
-$BafPath = "${env:APPDATA}\BAF"
+$BafPath = "`"${env:APPDATA}\BAF`""
 $Response = Invoke-WebRequest -URI "https://api.github.com/repos/Hannesimo/auto-flipper/releases" -UseBasicParsing
 $Releases = ConvertFrom-Json $Response.Content
 
@@ -37,4 +37,4 @@ else {
 }
 
 Write-Output "Starting BAF..."
-Invoke-Expression "${BafPath}\${ExecutableName}"
+Invoke-Expression "`"$BafPath\${ExecutableName}`""


### PR DESCRIPTION
The powershell script had an issue, that the script would immediately cancel after opening if the windows username contained a space. This commit should fix the issue by changing the BafPath variable.